### PR TITLE
Fix for issue 97: mapping of video stream will fail if it is a video stream with a mimetype of image/jpeg

### DIFF
--- a/lib/unffmpeg/video_codec_handle.py
+++ b/lib/unffmpeg/video_codec_handle.py
@@ -63,6 +63,15 @@ class VideoCodecHandle(object):
                 # By default the video stream will be re-encoded
                 just_copy_video_stream = False
 
+                # Check for more details about the stream
+                if 'tags' in stream:
+                    # Is 'mimetype' in the tags
+                    if 'mimetype' in stream['tags']:
+                        # If this video stream is really an embedded jpeg file (image/jpeg)
+                        # simply copy the stream
+                        if stream['tags']['mimetype'] == 'image/jpeg':
+                            just_copy_video_stream = True
+
                 # If this video encoding is disabled. Then copy the stream
                 if self.disable_video_encoding:
                     just_copy_video_stream = True


### PR DESCRIPTION
Issue 97: [https://github.com/Josh5/unmanic/issues/97]

If a video stream is simply an embedded image (e.g. cover.jpg), ffmpeg will fail with the following error:

x265 [error]: Picture height must be an integer multiple of the specified chroma subsampling
[libx265 @ 0x56359090bd00] Cannot open libx265 encoder.
Error initializing output stream 0:1 -- Error while opening encoder for output stream #0:1 - maybe incorrect parameters such as bit_rate, rate, width or height

if I remove the mjpeg video stream, ffmpeg works fine and produces a working file.

**The code merge is to simply copy the stream.** 
