### PR TITLE
Keep filename history

### DIFF
--- a/lib/fileinfo.py
+++ b/lib/fileinfo.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+###################################################################################################
+#
+#   Written by:               Wagner Caixeta <wagner.caixeta@gmail.com>
+#   Date:                     Thu Apr 23 2020, (15:25:00 PM)
+#
+#   Copyright:
+#          Copyright (C) Josh Sunnex - All Rights Reserved
+#
+#          Permission is hereby granted, free of charge, to any person obtaining a copy
+#          of this software and associated documentation files (the "Software"), to deal
+#          in the Software without restriction, including without limitation the rights
+#          to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#          copies of the Software, and to permit persons to whom the Software is
+#          furnished to do so, subject to the following conditions:
+#
+#          The above copyright notice and this permission notice shall be included in all
+#          copies or substantial portions of the Software.
+#
+#          THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#          EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#          MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#          IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#          DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+#          OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+#          OR OTHER DEALINGS IN THE SOFTWARE.
+#
+#
+###################################################################################################
+
+import re, os
+
+"""
+
+An object to represent .file_info (Filebot pattern to keep filename history)
+
+"""
+
+class FileInfo(object):
+    """
+    FileInfo
+
+    Attributes:
+        path (string): Path of .file_info
+        entries (array of Entry): Filename history
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.entries = []
+    
+    def append(self, newname, originalname):
+        self.entries.append(Entry(newname, self._find_oldest_name(originalname)))
+    
+    def load(self):
+        if os.path.exists(self.path):
+            try:
+                f = open(self.path)
+                self.entries = []
+                for line in f:
+                    m = re.search('(.+)="(.+)"', line)
+                    if m.group(1) is not None and m.group(2) is not None:
+                        self.entries.append(Entry(m.group(1), m.group(2)))
+            except IOError:
+                print("File not accessible")
+            finally:
+                f.close()
+
+    def save(self):
+        try:
+            f = open(self.path, "w")
+            for entry in self.entries:
+                f.write('%s="%s"\n' % (entry.newname, entry.originalname))
+        except IOError:
+            print("File not accessible")
+        finally:
+            f.close()
+
+    def _find_oldest_name(self, filename):
+        for entry in self.entries:
+            if entry.newname == filename:
+                return entry.originalname
+        return filename
+
+"""
+
+An object to keep a pair of newname and originalname
+
+"""
+class Entry(object):
+    """
+    Entry
+
+    Attributes:
+        newname (string): New name of file
+        originalname (string): Old name of file
+    """
+
+    def __init__(self, newname, originalname):
+        self.newname = newname
+        self.originalname = originalname

--- a/lib/fileinfo.py
+++ b/lib/fileinfo.py
@@ -34,7 +34,7 @@ import re, os
 
 """
 
-An object to represent .file_info (Filebot pattern to keep filename history)
+An object to represent file_info (Filebot pattern to keep filename history)
 
 """
 
@@ -43,7 +43,7 @@ class FileInfo(object):
     FileInfo
 
     Attributes:
-        path (string): Path of .file_info
+        path (string): Path of file_info
         entries (array of Entry): Filename history
     """
 

--- a/lib/postprocessor.py
+++ b/lib/postprocessor.py
@@ -35,6 +35,7 @@ import shutil
 import threading
 import time
 
+from lib.fileinfo import FileInfo
 from lib import common, history, unffmpeg
 
 """
@@ -119,6 +120,8 @@ class PostProcessor(threading.Thread):
                 # TODO: Add env variable option to keep src
                 if self.current_task.source['abspath'] != self.current_task.destination['abspath']:
                     self._log("Removing source: {}".format(self.current_task.source['abspath']))
+                    if self.settings.KEEP_FILENAME_HISTORY:
+                        self.keep_filename_history(self.current_task.source["dirname"], self.current_task.destination["basename"], self.current_task.source["basename"])
                     os.remove(self.current_task.source['abspath'])
             else:
                 self._log("Copy / Replace failed during post processing '{}'".format(self.current_task.cache_path),
@@ -172,3 +175,14 @@ class PostProcessor(threading.Thread):
                 'task_dump':           task_dump,
             }
         )
+
+    def keep_filename_history(self, basedir, newname, originalname):
+        """
+        Write filename history in .file_info (Filebot pattern usefull for download subtitles using original filename)
+
+        :return:
+        """
+        fileinfo = FileInfo("{}/.file_info".format(basedir))
+        fileinfo.load()
+        fileinfo.append(newname, originalname)
+        fileinfo.save()

--- a/lib/postprocessor.py
+++ b/lib/postprocessor.py
@@ -178,11 +178,11 @@ class PostProcessor(threading.Thread):
 
     def keep_filename_history(self, basedir, newname, originalname):
         """
-        Write filename history in .file_info (Filebot pattern usefull for download subtitles using original filename)
+        Write filename history in file_info (Filebot pattern usefull for download subtitles using original filename)
 
         :return:
         """
-        fileinfo = FileInfo("{}/.file_info".format(basedir))
+        fileinfo = FileInfo("{}/file_info".format(basedir))
         fileinfo.load()
         fileinfo.append(newname, originalname)
         fileinfo.save()

--- a/lib/unmodels/settings.py
+++ b/lib/unmodels/settings.py
@@ -50,6 +50,7 @@ class Settings(BaseModel):
     audio_stereo_stream_bitrate = TextField(null=False, default='128k')
     cache_path = TextField(null=False, default='/tmp/unmanic')
     config_path = TextField(null=False, default=os.path.join(HOME_DIR, '.unmanic', 'config'))
+    keep_filename_history = BooleanField(null=False, default=True)
     debugging = BooleanField(null=False, default=False)
     enable_audio_encoding = BooleanField(null=False, default=True)
     enable_audio_stream_transcoding = BooleanField(null=False, default=True)

--- a/migrations/004_keep_filename_history.py
+++ b/migrations/004_keep_filename_history.py
@@ -1,0 +1,41 @@
+"""Peewee migrations -- 004_keep_filename_history.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import peewee as pw
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    # Add keep_filename_history field to Settings Model
+    migrator.add_fields('settings', keep_filename_history=pw.BooleanField(default=True, null=False))
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    # Remove the keep_filename_history field from the Settings Model
+    migrator.remove_fields('settings', 'keep_filename_history', cascade=True)

--- a/webserver/templates/settings/general/settings-general.html
+++ b/webserver/templates/settings/general/settings-general.html
@@ -117,7 +117,7 @@
                                         <label>
                                             <input type="checkbox" id="keep_filename_history_enabled" onchange="toggleKeepFilenameHistory();" {% if config.KEEP_FILENAME_HISTORY %} checked {% end %} />
                                         </label>
-                                        <span class="help-inline">If enabled, unmanic will keep a filename history using FileBot pattern (.file_info). Useful for Sub-Zero Plex Plugin and other subtitles downloaders.</span>
+                                        <span class="help-inline">If enabled, unmanic will keep a filename history using FileBot pattern (file_info). Useful for Sub-Zero Plex Plugin and other subtitles downloaders.</span>
                                     </div>
                                 </div>
                             </div>

--- a/webserver/templates/settings/general/settings-general.html
+++ b/webserver/templates/settings/general/settings-general.html
@@ -117,7 +117,7 @@
                                         <label>
                                             <input type="checkbox" id="keep_filename_history_enabled" onchange="toggleKeepFilenameHistory();" {% if config.KEEP_FILENAME_HISTORY %} checked {% end %} />
                                         </label>
-                                        <span class="help-inline"> If enabled, when a file is renamed a .file_info is created to keep original filename (FileBot pattern). Useful for Sub-Zero Plex Plugin and other subtitles downloaders.</span>
+                                        <span class="help-inline">If enabled, unmanic will keep a filename history using FileBot pattern (.file_info). Useful for Sub-Zero Plex Plugin and other subtitles downloaders.</span>
                                     </div>
                                 </div>
                             </div>

--- a/webserver/templates/settings/general/settings-general.html
+++ b/webserver/templates/settings/general/settings-general.html
@@ -103,6 +103,26 @@
                             </div>
                             <hr />
                             <div class="caption">
+                                <span class="caption-subject font-dark sbold uppercase">Keep Filename History</span>
+                                <br>
+                                <span class="help-inline">
+                                </span>
+                            </div>
+                            <br>
+                            <div class="form-group">
+                                <label class="col-md-3 control-label">Keep Filename History</label>
+                                <div class="col-md-9">
+                                    <div class="checkbox-list">
+                                            <input type="hidden" name="KEEP_FILENAME_HISTORY" id="KEEP_FILENAME_HISTORY" value="{% if config.KEEP_FILENAME_HISTORY %}true{% end %}" > 
+                                        <label>
+                                            <input type="checkbox" id="keep_filename_history_enabled" onchange="toggleKeepFilenameHistory();" {% if config.KEEP_FILENAME_HISTORY %} checked {% end %} />
+                                        </label>
+                                        <span class="help-inline"> If enabled, when a file is renamed a .file_info is created to keep original filename (FileBot pattern). Useful for Sub-Zero Plex Plugin and other subtitles downloaders.</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <hr />
+                            <div class="caption">
                                 <span class="caption-subject font-dark sbold uppercase">Debugging</span>
                                 <br>
                                 <span class="help-inline">

--- a/webserver/templates/settings/settings.html
+++ b/webserver/templates/settings/settings.html
@@ -19,6 +19,13 @@
             $("#ENABLE_INOTIFY").val("false");
         }
     };
+    var toggleKeepFilenameHistory = function () {
+        if ($("#keep_filename_history_enabled").prop("checked")) {
+            $("#KEEP_FILENAME_HISTORY").val("true");
+        } else {
+            $("#KEEP_FILENAME_HISTORY").val("false");
+        }
+    };
     var toggleDebugging = function () {
         if ($("#debugging_enabled").prop("checked")) {
             $("#DEBUGGING").val("true");


### PR DESCRIPTION
If enabled, unmanic will keep a filename history using FileBot pattern (file_info). Useful for Sub-Zero Plex Plugin and other subtitles downloaders.