### PR TITLE
Fix: no redirect after change settings

### DIFF
--- a/webserver/settings.py
+++ b/webserver/settings.py
@@ -62,7 +62,7 @@ class SettingsUIRequestHandler(tornado.web.RequestHandler):
                 value = self.get_arguments(config_item)
                 if value:
                     self.config.set_config_item(config_item, value[0])
-            self.redirect(path)
+            self.redirect(self.request.uri)
 
     def handle_ajax_post(self):
         query = self.get_argument('ajax')


### PR DESCRIPTION
After POST /settings
`self.redirect(path)`
was doing nothing so i replaced it with
`self.redirect(self.request.uri)`
path var was empty.