### PR TITLE
creating-stereo-stream-causing-unintentional-downmix

### DIFF
--- a/lib/unffmpeg/audio_codec_handle.py
+++ b/lib/unffmpeg/audio_codec_handle.py
@@ -110,7 +110,7 @@ class AudioCodecHandle(object):
         self.encoding_args['streams_to_encode'] = self.encoding_args['streams_to_encode'] + [
             "-c:a:{}".format(self.audio_tracks_count), self.audio_encoder_cloning,
             "-b:a:{}".format(self.audio_tracks_count), self.audio_stereo_stream_bitrate,
-            "-ac", "2",
+            "-ac:a:{}".format(self.audio_tracks_count), "2",
             "-metadata:s:a:{}".format(self.audio_tracks_count), "title='{}'".format(audio_tag),
         ]
         self.audio_tracks_count += 1


### PR DESCRIPTION
If you create a stereo stream in the app, all audio streams are unintentional downmixed to stereo. This fixes that.