### PR TITLE
handle unsupported subtitles

### DIFF
--- a/lib/unffmpeg/base_containers.py
+++ b/lib/unffmpeg/base_containers.py
@@ -74,3 +74,14 @@ class Containers(object):
         if self.container_supports_subtitles():
             return self.subtitle_codecs
         return []
+
+    def unsupported_subtitles(self):
+        """
+        Check if this Container supports subtitles
+
+        :return:
+        """
+        if hasattr(self, 'unsupports_codecs'):
+            return self.unsubtitle_codecs
+        # HDMV streams cannont be written by FFMPEG
+        return ['hdmv_pgs_subtitle']

--- a/lib/unffmpeg/subtitle_handle.py
+++ b/lib/unffmpeg/subtitle_handle.py
@@ -85,10 +85,15 @@ class SubtitleHandle(object):
                     # Transcode the stream to a format that the destination container does support
                     # TODO: Check if it can be re-encoded. It is not possible to switch between image and text format
                     # If dest container supports the current subtitle codec, just copy it
-                    self.subtitle_args['streams_to_encode'] = self.subtitle_args['streams_to_encode'] + [
-                        "-c:s:{}".format(subtitle_tracks_count), "{}".format(supported_subtitles[0])
-                    ]
-                    subtitle_tracks_count += 1
+                    # unsupported subtitles will need to be removed, otherwise ffmpeg will not convert
+                    unsupported_subtitles = self.container.unsupported_subtitles()
+                    if stream['codec_name'] in unsupported_subtitles:
+                        continue
+                    else:
+                        self.subtitle_args['streams_to_encode'] = self.subtitle_args['streams_to_encode'] + [
+                            "-c:s:{}".format(subtitle_tracks_count), "{}".format(supported_subtitles[0])
+                        ]
+                        subtitle_tracks_count += 1
 
                 # Map this stream if it was marked above as compatible with the destination
                 self.subtitle_args['streams_to_map'] = self.subtitle_args['streams_to_map'] + [

--- a/webserver/templates/settings/container/settings-container.html
+++ b/webserver/templates/settings/container/settings-container.html
@@ -60,6 +60,7 @@
                                     </label>
                                 </div>
                                 <span class="help-inline"> Removes the subtitle stream from the container. This is useful if you intend to supply your own subtitles for your library </span>
+                                <span class="help-inline" style="color:darkred"> WARNING: Unsupported subtitles will always be removed</span>
                             </div>
                         </div>
 


### PR DESCRIPTION
If unsupported subtitles are present in the app. FFmpeg refuses to convert the file. This will remove unsupported subtitles so that the file can process. This also puts a warning message on the screen, informing the user that unsupported subtitles will always be removed.