### PR TITLE
Handle multiple video streams

### DIFF
--- a/unmanic/libs/postprocessor.py
+++ b/unmanic/libs/postprocessor.py
@@ -186,19 +186,19 @@ class PostProcessor(threading.Thread):
             self._log("Exception in method process_file", str(e), level='exception')
             return False
 
-        result = True
+        result = False
         for stream in file_probe['streams']:
             if stream['codec_type'] == 'video':
                 if self.settings.ENABLE_VIDEO_ENCODING:
                     # Check if this file is the right codec
                     if stream['codec_name'] == self.settings.VIDEO_CODEC:
-                        continue
+                        result = True
                     elif self.settings.DEBUGGING:
-                        self._log("File is the not correct codec {} - {}".format(self.settings.VIDEO_CODEC, abspath))
+                        self._log("File is the not correct codec {} - {} :: {}".format(self.settings.VIDEO_CODEC, abspath, stream['codec_name']))
                         # TODO: If settings are modified during a conversion, the file being converted should not fail.
                         #  Modify ffmpeg.py to have settings passed to it rather than reading directly from the config object
                         #  Test against the task's configured video codec
-                        result = False
+                        continue
                     # TODO: Test duration is the same as src
                     # TODO: Add file checksum from before and after move
 

--- a/unmanic/libs/postprocessor.py
+++ b/unmanic/libs/postprocessor.py
@@ -193,12 +193,12 @@ class PostProcessor(threading.Thread):
                     # Check if this file is the right codec
                     if stream['codec_name'] == self.settings.VIDEO_CODEC:
                         result = True
+                        continue
                     elif self.settings.DEBUGGING:
                         self._log("File is the not correct codec {} - {} :: {}".format(self.settings.VIDEO_CODEC, abspath, stream['codec_name']))
                         # TODO: If settings are modified during a conversion, the file being converted should not fail.
                         #  Modify ffmpeg.py to have settings passed to it rather than reading directly from the config object
                         #  Test against the task's configured video codec
-                        continue
                     # TODO: Test duration is the same as src
                     # TODO: Add file checksum from before and after move
 

--- a/unmanic/libs/unffmpeg/video_codec_handle.py
+++ b/unmanic/libs/unffmpeg/video_codec_handle.py
@@ -43,6 +43,7 @@ class VideoCodecHandle(object):
     def __init__(self, file_probe):
         self.file_probe = file_probe
         self.encoding_args = {}
+        self.video_tracks_count = 0
 
         # Configurable settings
         self.disable_video_encoding = False
@@ -85,13 +86,15 @@ class VideoCodecHandle(object):
                 if just_copy_video_stream:
                     # Video stream just needs to be copied
                     self.encoding_args['streams_to_encode'] = self.encoding_args['streams_to_encode'] + [
-                        "-c:v", "copy"
+                        "-c:v:{}".format(self.video_tracks_count), "copy"
                     ]
                 else:
                     # Video stream to be re-encoded
                     self.encoding_args['streams_to_encode'] = self.encoding_args['streams_to_encode'] + [
-                        "-c:v", self.video_encoder
+                        "-c:v:{}".format(self.video_tracks_count), self.video_encoder
                     ]
+                
+                self.video_tracks_count += 1
 
                 # Map this video stream to be processed
                 self.encoding_args['streams_to_map'] = self.encoding_args['streams_to_map'] + [


### PR DESCRIPTION
This is a fix for issue #146.

Handle multiple video streams by including stream number in ffmpeg c:v option.