### PR TITLE
Follow links when scanning the library

### DIFF
--- a/unmanic/service.py
+++ b/unmanic/service.py
@@ -147,7 +147,7 @@ class LibraryScanner(threading.Thread):
     def get_convert_files(self, search_folder):
         if self.settings.DEBUGGING:
             self._log("Scanning directory - '{}'".format(search_folder), level="debug")
-        for root, subFolders, files in os.walk(search_folder):
+        for root, subFolders, files in os.walk(search_folder, followlinks=True):
             if self.settings.DEBUGGING:
                 self._log(json.dumps(files, indent=2), level="debug")
             # Add all files in this path that match our container filter


### PR DESCRIPTION
At the moment, you have no way to convert your whole library when it's stored in different locations (e.g. on different HDDs). 
The proposed changes would allow you to create a separate folder for unmanic, where all the target folders would be created as symlinks and you wouldn't need to reorganise your existing library.